### PR TITLE
4:3 Aspect Ratio Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a port of the Epic Noir theme (originally by [c64-dev & Chicuelo](https:
 - Redesigned the design/layout of system and gamelist views
 - Removed all Retropie specific elements to make the theme compatible with ES-DE v2.x
 - Updated system image names to match the standard used by ES-DE
-- Added a 16:10 Layout Variant
+- Added 16:10 and 4:3 Layouts Variants
 - Add support for ES-DE capabilities such as badges and aspect ratio switching
 - Embedded the ES-DE [system-metadata](https://gitlab.com/es-de/themes/system-metadata) repository to power system description, release year and hardware type details
 

--- a/_inc/images/background-gradient-43.svg
+++ b/_inc/images/background-gradient-43.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 1920 1080" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(1.65517,0,0,1,0,0)">
+        <rect id="Artboard1" x="0" y="0" width="1160" height="1080" style="fill:rgb(255,0,220);fill-opacity:0;"/>
+        <g id="Artboard11" serif:id="Artboard1">
+            <g transform="matrix(0.274392,0,0,2,7.10543e-14,0)">
+                <rect x="0" y="0" width="1920" height="540"/>
+            </g>
+            <g transform="matrix(3.17188,0,0,1,525.625,0)">
+                <rect x="0" y="0" width="200" height="1080" style="fill:url(#_Linear1);"/>
+            </g>
+        </g>
+    </g>
+    <defs>
+        <linearGradient id="_Linear1" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(200,0,0,200,0,0)">
+            <stop offset="0" style="stop-color:black;stop-opacity:1"/>
+            <stop offset="0.03" style="stop-color:black;stop-opacity:0.95"/>
+            <stop offset="0.06" style="stop-color:black;stop-opacity:0.85"/>
+            <stop offset="0.09" style="stop-color:black;stop-opacity:0.75"/>
+            <stop offset="0.12" style="stop-color:black;stop-opacity:0.65"/>
+            <stop offset="0.15" style="stop-color:black;stop-opacity:0.55"/>
+            <stop offset="0.18" style="stop-color:black;stop-opacity:0.45"/>
+            <stop offset="0.21" style="stop-color:black;stop-opacity:0.35"/>
+            <stop offset="0.24" style="stop-color:black;stop-opacity:0.25"/>
+            <stop offset="0.27" style="stop-color:black;stop-opacity:0.15"/>
+            <stop offset="0.3" style="stop-color:black;stop-opacity:0.05"/>
+            <stop offset="1" style="stop-color:black;stop-opacity:0"/>
+        </linearGradient>
+    </defs>
+</svg>

--- a/auto-allgames/theme.xml
+++ b/auto-allgames/theme.xml
@@ -7,13 +7,17 @@
       <gameselector name="selector_random">
          <selection>random</selection>
       </gameselector>
-      <video name="random-game">
-         <origin>0 0</origin>
-         <pos>0.588020833333333 0.327777777777778</pos><!-- 1129 354 -->
-         <cropSize>0.274479166666667 0.363888888888889</cropSize><!-- 526 393 -->
-         <imageType>screenshot</imageType>
-         <delay>3</delay>
-         <gameselector>selector_random</gameselector>
-      </video>
    </view>
+   <aspectRatio name="16:10,16:9">
+      <view name="system">
+         <video name="random-game">
+            <origin>0 0</origin>
+            <pos>0.588020833333333 0.327777777777778</pos><!-- 1129 354 -->
+            <cropSize>0.274479166666667 0.363888888888889</cropSize><!-- 526 393 -->
+            <imageType>screenshot</imageType>
+            <delay>3</delay>
+            <gameselector>selector_random</gameselector>
+         </video>
+      </view>
+   </aspectRatio>
 </theme>

--- a/auto-favorites/theme.xml
+++ b/auto-favorites/theme.xml
@@ -7,13 +7,17 @@
       <gameselector name="selector_random">
          <selection>random</selection>
       </gameselector>
-      <video name="random-game">
-         <origin>0 0</origin>
-         <pos>0.588020833333333 0.327777777777778</pos><!-- 1129 354 -->
-         <cropSize>0.274479166666667 0.363888888888889</cropSize><!-- 526 393 -->
-         <imageType>screenshot</imageType>
-         <delay>3</delay>
-         <gameselector>selector_random</gameselector>
-      </video>
    </view>
+   <aspectRatio name="16:10,16:9">
+      <view name="system">
+         <video name="random-game">
+            <origin>0 0</origin>
+            <pos>0.588020833333333 0.327777777777778</pos><!-- 1129 354 -->
+            <cropSize>0.274479166666667 0.363888888888889</cropSize><!-- 526 393 -->
+            <imageType>screenshot</imageType>
+            <delay>3</delay>
+            <gameselector>selector_random</gameselector>
+         </video>
+      </view>
+   </aspectRatio>
 </theme>

--- a/auto-lastplayed/theme.xml
+++ b/auto-lastplayed/theme.xml
@@ -7,13 +7,17 @@
       <gameselector name="selector_lastplayed">
          <selection>lastplayed</selection>
       </gameselector>
-      <video name="last-played-game">
-         <origin>0 0</origin>
-         <pos>0.588020833333333 0.327777777777778</pos><!-- 1129 354 -->
-         <cropSize>0.274479166666667 0.363888888888889</cropSize><!-- 526 393 -->
-         <imageType>screenshot</imageType>
-         <delay>3</delay>
-         <gameselector>selector_lastplayed</gameselector>
-      </video>
    </view>
+   <aspectRatio name="16:10,16:9">
+      <view name="system">
+         <video name="last-played-game">
+            <origin>0 0</origin>
+            <pos>0.588020833333333 0.327777777777778</pos><!-- 1129 354 -->
+            <cropSize>0.274479166666667 0.363888888888889</cropSize><!-- 526 393 -->
+            <imageType>screenshot</imageType>
+            <delay>3</delay>
+            <gameselector>selector_lastplayed</gameselector>
+         </video>
+      </view>
+   </aspectRatio>
 </theme>

--- a/capabilities.xml
+++ b/capabilities.xml
@@ -4,6 +4,7 @@
 
    <aspectRatio>16:9</aspectRatio>
    <aspectRatio>16:10</aspectRatio>
+   <aspectRatio>4:3</aspectRatio>
 
    <transitions name="transitions">
       <label>transitions</label>

--- a/completed/theme.xml
+++ b/completed/theme.xml
@@ -7,13 +7,17 @@
       <gameselector name="selector_lastplayed">
          <selection>lastplayed</selection>
       </gameselector>
-      <video name="last-played-game">
-         <origin>0 0</origin>
-         <pos>0.588020833333333 0.327777777777778</pos><!-- 1129 354 -->
-         <cropSize>0.274479166666667 0.363888888888889</cropSize><!-- 526 393 -->
-         <imageType>screenshot</imageType>
-         <delay>3</delay>
-         <gameselector>selector_lastplayed</gameselector>
-      </video>
    </view>
+   <aspectRatio name="16:10,16:9">
+      <view name="system">
+         <video name="last-played-game">
+            <origin>0 0</origin>
+            <pos>0.588020833333333 0.327777777777778</pos><!-- 1129 354 -->
+            <cropSize>0.274479166666667 0.363888888888889</cropSize><!-- 526 393 -->
+            <imageType>screenshot</imageType>
+            <delay>3</delay>
+            <gameselector>selector_lastplayed</gameselector>
+         </video>
+      </view>
+   </aspectRatio>
 </theme>

--- a/custom-collections/theme.xml
+++ b/custom-collections/theme.xml
@@ -41,4 +41,12 @@
          </text>
       </view>
    </aspectRatio>
+   <aspectRatio name="4:3">
+      <view name="gamelist">
+         <text name="custom-collection-name">
+            <pos>0.47 0.002</pos>
+            <size>0.444444444444444 0.075</size>
+         </text>
+      </view>
+   </aspectRatio>
 </theme>

--- a/now-playing/theme.xml
+++ b/now-playing/theme.xml
@@ -7,13 +7,17 @@
       <gameselector name="selector_lastplayed">
          <selection>lastplayed</selection>
       </gameselector>
-      <video name="last-played-game">
-         <origin>0 0</origin>
-         <pos>0.588020833333333 0.327777777777778</pos><!-- 1129 354 -->
-         <cropSize>0.274479166666667 0.363888888888889</cropSize><!-- 526 393 -->
-         <imageType>screenshot</imageType>
-         <delay>3</delay>
-         <gameselector>selector_lastplayed</gameselector>
-      </video>
    </view>
+   <aspectRatio name="16:10,16:9">
+      <view name="system">
+         <video name="last-played-game">
+            <origin>0 0</origin>
+            <pos>0.588020833333333 0.327777777777778</pos><!-- 1129 354 -->
+            <cropSize>0.274479166666667 0.363888888888889</cropSize><!-- 526 393 -->
+            <imageType>screenshot</imageType>
+            <delay>3</delay>
+            <gameselector>selector_lastplayed</gameselector>
+         </video>
+      </view>
+   </aspectRatio>
 </theme>

--- a/theme.xml
+++ b/theme.xml
@@ -402,6 +402,89 @@ license:       creative commons CC-BY-NC-SA
       </view>
    </aspectRatio>
 
+   <aspectRatio name="4:3">
+      <view name="system,gamelist">
+         <image name="background-gradient">
+            <path>./_inc/images/background-gradient-43.svg</path>
+         </image>
+      </view>
+      <view name="system">
+         <image name="system-nav-background">
+            <size>0.0640625 1</size><!-- 123 1080 -->
+         </image>
+         <textlist name="system-nav">
+            <size>0.063541666666667 0.666666666666667</size>
+         </textlist>
+         <text name="system-metadata">
+            <pos>0.12 0.0855</pos>
+            <size>0.320 0.033</size>
+         </text>
+         <text name="system-title-1-line">
+            <pos>0.116 0.110</pos>
+         </text>
+         <text name="system-title-2-lines-row-1">
+            <pos>0.12 0.122</pos>
+         </text>
+         <text name="system-title-2-lines-row-2">
+            <pos>0.116 0.14</pos>
+         </text>
+         <text name="game-count">
+            <pos>0.12 0.3411</pos>
+            <size>0.4 0.039</size>
+         </text>
+         <text name="system-description">
+            <pos>0.12 0.41</pos>
+            <size>0.45 0.14</size>
+         </text>
+         <helpsystem name="help">
+            <pos>0.12 0.565</pos>
+         </helpsystem>
+         <image name="system-controller">
+            <pos>0.12 0.72</pos>
+            <maxSize>0.22 0.22</maxSize>
+         </image>
+      </view>
+      <view name="gamelist">
+         <image name="gamelist-nav-background">
+            <size>0.358796296296297 1</size><!-- 620 1080 -->
+         </image>
+         <text name="gamelist-nav-title">
+            <pos>0.032222222222222 0</pos>
+            <size>0.222222222222222 0.08</size>
+         </text>
+         <textlist name="gamelist-nav">
+            <textHorizontalScrollDelay>1</textHorizontalScrollDelay>
+            <size>0.358796296296297 0.836666666666667</size><!-- 620 990 -->
+         </textlist>
+         <image name="gamelist-nav-border">
+            <pos>0.359375 0</pos>
+         </image>
+         <image name="gamelist-nav-emblem">
+            <size>0.119212962962963 0.083481481481481</size><!-- 206 88 -->
+         </image>
+         <text name="system-title">
+            <pos>0.38 0.002</pos>
+            <size>0.444444444444444 0.075</size>
+         </text>
+         <badges name="badges">
+            <pos>0.524 0.022</pos>
+            <size>0.333333333333333 0.036</size>
+         </badges>
+         <video name="game-artwork">
+            <pos>0.679398148148148 0.42</pos>
+            <maxSize>0.555555555555556 0.6</maxSize>
+         </video>
+         <text name="game-description">
+            <containerStartDelay>4</containerStartDelay>
+            <pos>0.679398148148148 0.74</pos>
+            <size>0.54 0.17</size>
+         </text>
+         <helpsystem name="help">
+            <pos>0.5 0.97</pos>
+         </helpsystem>
+      </view>
+   </aspectRatio>
+
    <view name="all">
       <sound name="systembrowse">
          <path>./_inc/sounds/systembrowse.wav</path>


### PR DESCRIPTION
The title says it all. 
- I removed video previews from collections in system view for this aspect ratio due to lack of space in the screen. 
- Since the help bar (at least in spanish language) is wider than the space it used to have in the screen, I put it in the center and at the bottom of the screen list and reserved a space for it, making the game list just a little shorter.
- I added a new background gradient only for this aspect ratio, because the posters were being hidden too much when the opacity started to fade at 50% of the screen, in the new gradient starts to fade at 30%.

![Screenshot_20250309_204911_ES-DE](https://github.com/user-attachments/assets/665689b5-1e27-4ee4-8b92-fb13f52b78f6)
![Screenshot_20250309_205003_ES-DE](https://github.com/user-attachments/assets/628ea94c-a76b-4f77-8da7-e8203bcfc848)
